### PR TITLE
Remove language development installations in favor to devenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 ## Features
 
 - Support processor architectures: x86_64 (only one for now, may be extended in the future).
-- Development: [Golang], [NodeJs] and [Python tools].
-  - IDEs: [VSCodium] installation (via Nixpkgs).
+- IDEs: [VSCodium] installation (via Nixpkgs).
 - Browsers: [Brave], [Firefox] and [Mullvad Browser] (via Nix).
 - Containers and virtualization: [Docker], [Podman] and [libvirtd].
 - Office: installs [OnlyOffice] (via Nixpkgs).
@@ -164,10 +163,8 @@ This project was inspired by [@geerlingguy]'s [Mac Development Ansible Playbook]
 [firefox]: https://www.mozilla.org/firefox/
 [git]: https://git-scm.com/
 [gnome]: https://www.gnome.org/
-[golang]: https://go.dev/
 [home manager]: https://github.com/nix-community/home-manager
 [libvirtd]: https://libvirt.org/manpages/libvirtd.html
-[nodejs]: https://nodejs.org/
 [keypass]: https://keepass.info/
 [mac development ansible playbook]: https://github.com/geerlingguy/mac-dev-playbook
 [mit]: https://opensource.org/licenses/MIT
@@ -179,7 +176,6 @@ This project was inspired by [@geerlingguy]'s [Mac Development Ansible Playbook]
 [openrgb]: https://gitlab.com/CalcProgrammer1/OpenRGB
 [pep-668]: https://peps.python.org/pep-0668/
 [podman]: https://podman.io/
-[python tools]: https://github.com/staticdev/ansible-role-python-developer
 [rclone]: https://rclone.org/
 [signal]: https://signal.org
 [vscodium]: https://vscodium.com/

--- a/default.config.yml
+++ b/default.config.yml
@@ -62,26 +62,7 @@ dotfiles_files:
   - .vimrc
   - .zshrc
 
-# Development
-## Go settings
-golang_developer: true
-golang_version: "1.21.5"
-
-## NodeJs settings
-nodejs_developer: true
-nodejs_version: "20.x"
-
-## Python settings
-python_developer: true
-pyenv_python_versions:
-  - 3.12.1
-  - 3.11.7
-pyenv_global:
-  - 3.12.1
-  - 3.11.7
-pyenv_virtualenvs: []
-
-# keyboard config
+# Keyboard config
 configure_keyboard: false
 keyboard_layout: us
 keyboard_variant: intl

--- a/main.yml
+++ b/main.yml
@@ -36,15 +36,6 @@
         - "OpenRGB/debian/changelog"
 
   roles:
-    - role: gantsign.golang
-      when: golang_developer
-    - role: geerlingguy.nodejs
-      when: nodejs_developer
-      become: true
-    - role: staticdev.pyenv
-      when: python_developer
-    - role: staticdev.python_developer
-      when: python_developer
     - role: geerlingguy.dotfiles
       when: configure_dotfiles
     - role: stefangweichinger.ansible_rclone

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,15 +1,7 @@
 ---
 roles:
-  - name: gantsign.golang
-    version: 3.2.5
   - name: geerlingguy.dotfiles
     version: 1.2.1
-  - name: geerlingguy.nodejs
-    version: 6.1.1
-  - name: staticdev.pyenv
-    version: 2.11.0
-  - name: staticdev.python_developer
-    version: 3.1.0
   - name: stefangweichinger.ansible_rclone
     version: 0.1.3
 


### PR DESCRIPTION
It is not necessary anymore to install Python, Golang and NPM globally since Devenv is doing it per project.